### PR TITLE
Fix sidebar in light theme

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -542,6 +542,12 @@ panel .text-link {
 	color: var(--uwp-global-front) !important;
 	border-bottom: none !important;
 }
+#sidebar-switcher-target:hover {
+  background: var(--uwp-tabbar-button-hover) !important;  
+}
+#sidebar-switcher-target.active {
+  background: var(--uwp-tabbar-button-hover-active) !important;
+}
 #sidebar-switcher-target > #sidebar-icon {
 	fill: var(--uwp-global-front) !important;
 }

--- a/css/colors/base-light.css
+++ b/css/colors/base-light.css
@@ -12,9 +12,9 @@
 	--uwp-urlbar: transparent;
 	--uwp-urlbar-blur: #FFFFFFC0;
 	--uwp-autocomplete-oneoffs: #333333;
-	--uwp-sidebar: #2A2A2A;
-	--uwp-sidebar-search: black;
-	--uwp-sidebar-box: black;
+	--uwp-sidebar: white;
+	--uwp-sidebar-search: white;
+	--uwp-sidebar-box: white;
 	--uwp-statuspanel: white;
 	--uwp-statuspanel-color: lightgray;
 	--uwp-navbar-button-hover: #E0E0E0;


### PR DESCRIPTION
Hi there, 

Just trying out your custom style theme after the recent round of changes to the UI (in FF 89) and just noticed a couple of minor background color updates required for the "light" theme in the sidebar where History, Bookmarks, Tree tabs, etc live.

Here's before:
![image](https://user-images.githubusercontent.com/2483849/121321545-896ba800-c951-11eb-884b-2715ab31c770.png)

And after:
![image](https://user-images.githubusercontent.com/2483849/121321602-97212d80-c951-11eb-9f84-a451d78319bd.png)

Hope this helps :)